### PR TITLE
Formatter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
             mkdir tmp
             git diff origin/master --name-only --diff-filter=d > tmp/files_to_lint
       - run:
-          name: Run rubocop
+          name: Run Rubocop
           shell: /bin/bash
           command: |
             cat tmp/files_to_lint | grep -E '.+\.(rb)$' | xargs bundle exec rubocop --force-exclusion \
@@ -65,6 +65,7 @@ jobs:
       - run:
           name: Run Tests
           command: |
+            mkdir tmp
             RSPEC_JUNIT_ARGS="-r rspec_junit_formatter -f RspecJunitFormatter -o test_results/rspec.xml"
             RSPEC_FORMAT_ARGS="-f progress --no-color -p 10"
             bundle exec rspec ./spec $RSPEC_FORMAT_ARGS $RSPEC_JUNIT_ARGS
@@ -80,9 +81,9 @@ jobs:
       - run:
           name: Publish to rubygems
           command: |
-            gem build active_job_log.gemspec
+            gem build simplecov_text_formatter.gemspec
             version_tag=$(git describe --tags)
-            gem push active_job_log-${version_tag#v}.gem
+            gem push simplecov_text_formatter-${version_tag#v}.gem
 
 workflows:
   version: 2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,12 +15,6 @@ GEM
     ast (2.4.2)
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
-    coveralls (0.8.23)
-      json (>= 1.8, < 3)
-      simplecov (~> 0.16.1)
-      term-ansicolor (~> 1.3)
-      thor (>= 0.19.4, < 2.0)
-      tins (~> 1.6)
     diff-lcs (1.4.4)
     docile (1.4.0)
     ffi (1.15.4)
@@ -41,7 +35,6 @@ GEM
       rspec (>= 2.99.0, < 4.0)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
-    json (2.5.1)
     listen (3.7.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -98,17 +91,13 @@ GEM
       rubocop (>= 1.7.0, < 2.0)
     ruby-progressbar (1.11.0)
     shellany (0.0.1)
-    simplecov (0.16.1)
+    simplecov (0.21.2)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
-    sync (0.5.0)
-    term-ansicolor (1.7.1)
-      tins (~> 1.0)
-    thor (1.1.0)
-    tins (1.29.1)
-      sync
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.3)
+    thor (0.18.1)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
@@ -119,7 +108,6 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 2.2.15)
-  coveralls
   guard-rspec
   pry
   rake (~> 12.0)
@@ -127,7 +115,7 @@ DEPENDENCIES
   rspec_junit_formatter
   rubocop (~> 1.9)
   rubocop-rails
-  simplecov
+  simplecov (~> 0.21)
   simplecov_text_formatter!
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Text formatter for SimpleCov code coverage tool
 
-***Note: To learn more about SimpleCov, check out the main repo at [https://github.com/simplecov-ruby/simplecov](https://github.com/colszowka/simplecov***)***
+***Note: To learn more about SimpleCov, check out the main repo at [https://github.com/simplecov-ruby/simplecov](https://github.com/colszowka/simplecov)***
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -5,16 +5,15 @@
 
 Text formatter for SimpleCov code coverage tool
 
+***Note: To learn more about SimpleCov, check out the main repo at [https://github.com/simplecov-ruby/simplecov](https://github.com/colszowka/simplecov***)***
+
 ## Installation
 
-```bash
-$ gem install simplecov_text_formatter
-```
-
-Or add to your Gemfile:
+Add to your Gemfile:
 
 ```ruby
-gem "simplecov_text_formatter"
+gem 'simplecov'
+gem 'simplecov_text_formatter'
 ```
 
 ```bash
@@ -23,7 +22,78 @@ bundle install
 
 ## Usage
 
-TODO
+Add the formatter to your `spec/spec_helper.rb`.
+
+```ruby
+require 'simplecov'
+require 'simplecov_text_formatter'
+
+SimpleCov.start 'rails' do
+  # ...
+
+  formatter SimpleCov::Formatter::MultiFormatter.new(
+    [
+      SimpleCov::Formatter::TextFormatter,
+      SimpleCov::Formatter::HTMLFormatter
+    ]
+  )
+end
+```
+
+Then run your test and check the file `coverage/coverage.txt`. You'll see something like this:
+
+```
+/app/channels/application_cable/channel.rb:1:1: Not covered lines: 1 to 4
+/app/channels/application_cable/connection.rb:1:1: Not covered lines: 1 to 4
+/app/controllers/api/v1/users_controller.rb:39:1: Not covered lines: 39
+/app/controllers/application_controller.rb:17:1: Not covered lines: 17
+/app/controllers/home_controller.rb:1:1: Not covered lines: 1 to 5
+/app/controllers/organizations_controller.rb:1:1: Not covered lines: 1 and 2
+/app/controllers/organizations_controller.rb:4:1: Not covered lines: 4 to 6
+/app/controllers/organizations_controller.rb:8:1: Not covered lines: 8 to 13
+/app/controllers/organizations_controller.rb:15:1: Not covered lines: 15
+/app/controllers/organizations_controller.rb:17:1: Not covered lines: 17 to 20
+/app/controllers/teams_controller.rb:1:1: Not covered lines: 1 and 2
+/app/controllers/teams_controller.rb:4:1: Not covered lines: 4 to 6
+/app/controllers/teams_controller.rb:8:1: Not covered lines: 8 to 11
+/app/controllers/teams_controller.rb:13:1: Not covered lines: 13
+/app/controllers/teams_controller.rb:15:1: Not covered lines: 15 to 18
+/app/controllers/users_controller.rb:13:1: Not covered lines: 13
+/app/controllers/users_controller.rb:17:1: Not covered lines: 17 and 18
+/app/controllers/users_controller.rb:28:1: Not covered lines: 28
+/app/jobs/application_job.rb:1:1: Not covered lines: 1
+/app/jobs/application_job.rb:7:1: Not covered lines: 7
+/app/models/user.rb:17:1: Not covered lines: 17
+/app/policies/active_admin/comment_policy.rb:1:1: Not covered lines: 1 and 2
+/app/policies/active_admin/page_policy.rb:1:1: Not covered lines: 1 to 5
+/app/policies/admin_user_policy.rb:1:1: Not covered lines: 1 and 2
+/app/policies/application_policy.rb:1:1: Not covered lines: 1 and 2
+/app/policies/application_policy.rb:4:1: Not covered lines: 4 to 7
+/app/policies/application_policy.rb:9:1: Not covered lines: 9 to 11
+/app/policies/application_policy.rb:13:1: Not covered lines: 13 to 15
+/app/policies/application_policy.rb:17:1: Not covered lines: 17 to 19
+/app/policies/application_policy.rb:21:1: Not covered lines: 21 to 23
+/app/policies/application_policy.rb:25:1: Not covered lines: 25 to 27
+/app/policies/application_policy.rb:29:1: Not covered lines: 29 to 31
+/app/policies/application_policy.rb:33:1: Not covered lines: 33 to 35
+/app/policies/application_policy.rb:37:1: Not covered lines: 37 and 38
+/app/policies/application_policy.rb:40:1: Not covered lines: 40 to 43
+/app/policies/application_policy.rb:45:1: Not covered lines: 45 to 47
+/app/policies/application_policy.rb:49:1: Not covered lines: 49 to 52
+/app/policies/application_policy.rb:54:1: Not covered lines: 54 to 57
+/app/policies/organization_policy.rb:1:1: Not covered lines: 1 and 2
+/app/policies/team_member_policy.rb:1:1: Not covered lines: 1 and 2
+/app/policies/team_policy.rb:1:1: Not covered lines: 1 and 2
+/app/policies/user_policy.rb:1:1: Not covered lines: 1 and 2
+/app/uploaders/base_uploader.rb:9:1: Not covered lines: 9
+/engines/dynattributes/app/commands/dynattributes/validate_date_attribute.rb:4:1: Not covered lines: 4
+/engines/dynattributes/app/commands/dynattributes/validate_date_time_attribute.rb:4:1: Not covered lines: 4
+/engines/dynattributes/app/commands/dynattributes/validate_select_definition.rb:4:1: Not covered lines: 4
+/engines/dynattributes/app/models/dynattributes/instance.rb:13:1: Not covered lines: 13 and 14
+/engines/dynattributes/app/models/dynattributes/instance.rb:16:1: Not covered lines: 16
+/engines/dynattributes/lib/dynattributes.rb:21:1: Not covered lines: 21
+/engines/tasks/lib/tasks.rb:20:1: Not covered lines: 20
+```
 
 ## Testing
 

--- a/lib/simplecov_text_formatter.rb
+++ b/lib/simplecov_text_formatter.rb
@@ -1,6 +1,33 @@
-require "simplecov_text_formatter/version"
+require 'simplecov_text_formatter/version'
+require 'simplecov_text_formatter/source_file_formatter'
+require 'simplecov_text_formatter/result_formatter'
+require 'simplecov_text_formatter/result_exporter'
 
-module SimplecovTextFormatter
-  class Error < StandardError; end
-  # Your code goes here...
+module SimpleCov
+  module Formatter
+    class TextFormatter
+      def format(result)
+        formatted_result = format_result(result)
+        export_formatted_result(formatted_result)
+        puts(output_message(result))
+      end
+
+      private
+
+      def format_result(result)
+        SimpleCovTextFormatter::ResultFormatter.new(result).format
+      end
+
+      def export_formatted_result(formatted_result)
+        SimpleCovTextFormatter::ResultExporter.new(formatted_result).export
+      end
+
+      def output_message(result)
+        <<~MSG
+          Text Coverage report generated for #{result.command_name} to #{SimpleCov.coverage_path}.
+          #{result.covered_lines} / #{result.total_lines} LOC (#{result.covered_percent.round(2)}%) covered.
+        MSG
+      end
+    end
+  end
 end

--- a/lib/simplecov_text_formatter/result_exporter.rb
+++ b/lib/simplecov_text_formatter/result_exporter.rb
@@ -1,0 +1,21 @@
+module SimpleCovTextFormatter
+  class ResultExporter
+    FILENAME = 'coverage.txt'
+
+    def initialize(errors_list)
+      @result = errors_list
+    end
+
+    def export
+      File.open(export_path, 'w') do |file|
+        file << @result.join("\n")
+      end
+    end
+
+    private
+
+    def export_path
+      File.join(SimpleCov.coverage_path, FILENAME)
+    end
+  end
+end

--- a/lib/simplecov_text_formatter/result_formatter.rb
+++ b/lib/simplecov_text_formatter/result_formatter.rb
@@ -1,0 +1,25 @@
+module SimpleCovTextFormatter
+  class ResultFormatter
+    def initialize(result)
+      @result = result
+    end
+
+    def format
+      formatted_result = []
+
+      @result.files.each do |source_file|
+        messages = format_source_file(source_file)
+        formatted_result += messages if messages
+      end
+
+      formatted_result
+    end
+
+    private
+
+    def format_source_file(source_file)
+      source_file_formatter = SourceFileFormatter.new(source_file)
+      source_file_formatter.format
+    end
+  end
+end

--- a/lib/simplecov_text_formatter/source_file_formatter.rb
+++ b/lib/simplecov_text_formatter/source_file_formatter.rb
@@ -1,0 +1,88 @@
+module SimpleCovTextFormatter
+  class SourceFileFormatter
+    NOT_COVERED_LINE_CODE = 0
+    VALID_MSG_PARTS_COUNT = 4
+    FILE_COLUMN = 1
+
+    def initialize(source_file)
+      @source_file = source_file
+    end
+
+    def format
+      not_covered_lines_in_batches.map do |batch|
+        build_message(batch)
+      end.reject(&:nil?)
+    end
+
+    private
+
+    def build_message(batch)
+      message_parts = build_message_parts(batch)
+      return unless message_parts.count == VALID_MSG_PARTS_COUNT
+      return if full_coverage?
+
+      message_parts.join(":")
+    end
+
+    def build_message_parts(batch)
+      [
+        @source_file.filename,
+        batch.first.to_s,
+        FILE_COLUMN.to_s,
+        " Not covered lines: #{build_error_text(batch)}"
+      ].reject(&:nil?)
+    end
+
+    def build_error_text(batch)
+      case batch.count
+      when 1
+        batch.first
+      when 2
+        "#{batch.first} and #{batch.last}"
+      else
+        "#{batch.first} to #{batch.last}"
+      end
+    end
+
+    def not_covered_lines_in_batches
+      line_numbers = not_covered_lines.map(&:line_number).sort
+      batches = []
+      current_batch = []
+
+      line_numbers.each_with_index do |line_number, index|
+        current_batch << line_number
+
+        if line_number + 1 != line_numbers[index + 1]
+          batches << current_batch
+          current_batch = []
+        end
+      end
+
+      batches
+    end
+
+    def full_coverage?
+      covered_percentage.to_i == 100
+    end
+
+    def covered_percentage
+      @covered_percentage ||= (covered_lines.count.to_f / valid_lines.count * 100).round(2)
+    end
+
+    def covered_lines
+      @covered_lines ||= lines.select { |l| l.coverage && l.coverage > NOT_COVERED_LINE_CODE }
+    end
+
+    def not_covered_lines
+      @not_covered_lines ||= lines.select { |l| l.coverage == NOT_COVERED_LINE_CODE }
+    end
+
+    def valid_lines
+      @valid_lines ||= lines.reject { |l| l.coverage.nil? }
+    end
+
+    def lines
+      @lines ||= @source_file.lines
+    end
+  end
+end

--- a/lib/simplecov_text_formatter/source_file_formatter.rb
+++ b/lib/simplecov_text_formatter/source_file_formatter.rb
@@ -52,13 +52,17 @@ module SimpleCovTextFormatter
       line_numbers.each_with_index do |line_number, index|
         current_batch << line_number
 
-        if line_number + 1 != line_numbers[index + 1]
+        if !near_lines?(line_number, line_numbers[index + 1])
           batches << current_batch
           current_batch = []
         end
       end
 
       batches
+    end
+
+    def near_lines?(line, next_line)
+      [*line..line + 2].include?(next_line)
     end
 
     def full_coverage?

--- a/simplecov_text_formatter.gemspec
+++ b/simplecov_text_formatter.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 2.2.15"
-  spec.add_development_dependency "coveralls"
   spec.add_development_dependency "guard-rspec"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake"
@@ -26,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec_junit_formatter"
   spec.add_development_dependency "rubocop", "~> 1.9"
   spec.add_development_dependency "rubocop-rails"
-  spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "simplecov", "~> 0.21"
 end

--- a/spec/result_exporter_spec.rb
+++ b/spec/result_exporter_spec.rb
@@ -1,0 +1,31 @@
+require "spec_helper"
+
+describe SimpleCovTextFormatter::ResultExporter do
+  let(:coverage_file_path) { "./tmp/coverage.txt" }
+  let(:errors_list) do
+    %w{
+      error1
+      error2
+    }
+  end
+
+  def coverage_file_content
+    described_class.new(errors_list).export
+    File.open(coverage_file_path).read
+  end
+
+  def delete_coverage_file
+    FileUtils.rm(coverage_file_path)
+  rescue Errno::ENOENT
+    nil
+  end
+
+  before do
+    delete_coverage_file
+    allow(SimpleCov).to receive(:coverage_path).and_return("./tmp")
+  end
+
+  after { delete_coverage_file }
+
+  it { expect(coverage_file_content).to eq("error1\nerror2") }
+end

--- a/spec/result_formatter_spec.rb
+++ b/spec/result_formatter_spec.rb
@@ -1,0 +1,58 @@
+require "spec_helper"
+
+describe SimpleCovTextFormatter::ResultFormatter do
+  let(:file1) { double }
+  let(:file1_formatter_response) do
+    [
+      1
+    ]
+  end
+
+  let(:file1_formatter) do
+    instance_double(
+      "SimpleCovTextFormatter::SourceFileFormatter",
+      format: file1_formatter_response
+    )
+  end
+
+  let(:file2) { double }
+  let(:file2_formatter_response) do
+    [
+      2
+    ]
+  end
+
+  let(:file2_formatter) do
+    instance_double(
+      "SimpleCovTextFormatter::SourceFileFormatter",
+      format: file2_formatter_response
+    )
+  end
+
+  let(:files) { [file1, file2] }
+
+  let(:result) do
+    double(
+      files: files
+    )
+  end
+
+  def format
+    described_class.new(result).format
+  end
+
+  before do
+    allow(SimpleCovTextFormatter::SourceFileFormatter).to receive(:new)
+      .and_return(file1_formatter, file2_formatter)
+  end
+
+  it { expect(format).to eq([1, 2]) }
+
+  context "with nil file formatter result" do
+    let(:file1_formatter_response) do
+      nil
+    end
+
+    it { expect(format).to eq([2]) }
+  end
+end

--- a/spec/simplecov_text_formatter_spec.rb
+++ b/spec/simplecov_text_formatter_spec.rb
@@ -1,15 +1,34 @@
 require "spec_helper"
 
-describe SimplecovTextFormatter do
+describe SimpleCov::Formatter::TextFormatter do
+  let(:result) do
+    double(
+      command_name: "X",
+      covered_lines: 1,
+      total_lines: 10,
+      covered_percent: 10
+    )
+  end
+
+  let(:result_formatter) do
+    double(format: true)
+  end
+
+  let(:result_exporter) do
+    double(export: true)
+  end
+
+  def format
+    described_class.new.format(result)
+  end
+
   before do
-    helper_example
+    allow(SimpleCovTextFormatter::ResultFormatter)
+      .to receive(:new).and_return(result_formatter)
+
+    allow(SimpleCovTextFormatter::ResultExporter)
+      .to receive(:new).and_return(result_exporter)
   end
 
-  it "has a version number" do
-    expect(SimplecovTextFormatter::VERSION).not_to be nil
-  end
-
-  it "does something useful" do
-    expect(false).to eq(true)
-  end
+  it { expect(format).to eq(nil) }
 end

--- a/spec/source_file_formatter_spec.rb
+++ b/spec/source_file_formatter_spec.rb
@@ -98,6 +98,31 @@ describe SimpleCovTextFormatter::SourceFileFormatter do
     it { expect(format).to eq(expected_lines) }
   end
 
+  context "with two near not consecutive lines" do
+    let(:line2) do
+      instance_double(
+        "SimpleCov::SourceFile::Line",
+        coverage: 0,
+        line_number: 3
+      )
+    end
+
+    let(:lines) do
+      [
+        line,
+        line2
+      ]
+    end
+
+    let(:expected_lines) do
+      [
+        "file.rb:1:1: Not covered lines: 1 and 3"
+      ]
+    end
+
+    it { expect(format).to eq(expected_lines) }
+  end
+
   context "with more than two consecutive lines" do
     let(:line2) do
       instance_double(

--- a/spec/source_file_formatter_spec.rb
+++ b/spec/source_file_formatter_spec.rb
@@ -1,0 +1,134 @@
+require "spec_helper"
+
+describe SimpleCovTextFormatter::SourceFileFormatter do
+  let(:line) do
+    instance_double(
+      "SimpleCov::SourceFile::Line",
+      coverage: 0,
+      line_number: 1
+    )
+  end
+
+  let(:lines) do
+    [
+      line
+    ]
+  end
+
+  let(:source_file) do
+    instance_double(
+      "SimpleCov::SourceFile",
+      filename: "file.rb",
+      lines: lines
+    )
+  end
+
+  def format
+    described_class.new(source_file).format
+  end
+
+  let(:expected_lines) do
+    [
+      "file.rb:1:1: Not covered lines: 1"
+    ]
+  end
+
+  it { expect(format).to eq(expected_lines) }
+
+  context "with no lines" do
+    let(:lines) do
+      []
+    end
+
+    let(:expected_lines) do
+      []
+    end
+
+    it { expect(format).to eq(expected_lines) }
+  end
+
+  context "with two consecutive lines" do
+    let(:line2) do
+      instance_double(
+        "SimpleCov::SourceFile::Line",
+        coverage: 0,
+        line_number: 2
+      )
+    end
+
+    let(:lines) do
+      [
+        line,
+        line2
+      ]
+    end
+
+    let(:expected_lines) do
+      [
+        "file.rb:1:1: Not covered lines: 1 and 2"
+      ]
+    end
+
+    it { expect(format).to eq(expected_lines) }
+  end
+
+  context "with two not consecutive lines" do
+    let(:line2) do
+      instance_double(
+        "SimpleCov::SourceFile::Line",
+        coverage: 0,
+        line_number: 4
+      )
+    end
+
+    let(:lines) do
+      [
+        line,
+        line2
+      ]
+    end
+
+    let(:expected_lines) do
+      [
+        "file.rb:1:1: Not covered lines: 1",
+        "file.rb:4:1: Not covered lines: 4"
+      ]
+    end
+
+    it { expect(format).to eq(expected_lines) }
+  end
+
+  context "with more than two consecutive lines" do
+    let(:line2) do
+      instance_double(
+        "SimpleCov::SourceFile::Line",
+        coverage: 0,
+        line_number: 2
+      )
+    end
+
+    let(:line3) do
+      instance_double(
+        "SimpleCov::SourceFile::Line",
+        coverage: 0,
+        line_number: 3
+      )
+    end
+
+    let(:lines) do
+      [
+        line,
+        line2,
+        line3
+      ]
+    end
+
+    let(:expected_lines) do
+      [
+        "file.rb:1:1: Not covered lines: 1 to 3"
+      ]
+    end
+
+    it { expect(format).to eq(expected_lines) }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,4 @@ Dir[File.join(path)].sort.each { |f| require f }
 RSpec.configure do |config|
   config.filter_run :focus
   config.run_all_when_everything_filtered = true
-
-  config.include TestHelpers
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 require 'simplecov'
-require 'coveralls'
+require "simplecov_text_formatter"
 
-formatters = [SimpleCov::Formatter::HTMLFormatter, Coveralls::SimpleCov::Formatter]
+formatters = [SimpleCov::Formatter::HTMLFormatter, SimpleCov::Formatter::TextFormatter]
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter::new(formatters)
 
 SimpleCov.start do
@@ -10,7 +10,6 @@ SimpleCov.start do
 end
 
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
-require "simplecov_text_formatter"
 require "pry"
 
 path = [File.dirname(__FILE__), "support", "**", "*.rb"]

--- a/spec/support/test_helpers.rb
+++ b/spec/support/test_helpers.rb
@@ -1,5 +1,0 @@
-module TestHelpers
-  def helper_example
-    puts "Add your custom helpers here: #{File.dirname(__FILE__)}"
-  end
-end


### PR DESCRIPTION
Hice un formatter para la gema https://github.com/simplecov-ruby/simplecov

La gema toma objetos de simplecov que tienen resultados de code coverage. Por ej:

![image](https://user-images.githubusercontent.com/3026413/134244486-a065f660-0113-4198-b129-7e8fbefcabc8.png)

y la convierte en algo así:

```
/app/channels/application_cable/channel.rb:1:1: Not covered lines: 1 to 4
/app/channels/application_cable/connection.rb:1:1: Not covered lines: 1 to 4
/app/controllers/api/v1/users_controller.rb:39:1: Not covered lines: 39
/app/controllers/application_controller.rb:17:1: Not covered lines: 17
/app/controllers/home_controller.rb:1:1: Not covered lines: 1 to 5
/app/controllers/organizations_controller.rb:1:1: Not covered lines: 1 and 2
...
```

Ese archivo de texto resultante lo usaré junto a https://github.com/reviewdog/reviewdog (lo que usamos con los linters) para comentar en los PRs

```
cat coverage/coverage.txt | ./bin/reviewdog -reporter=github-pr-review -f=golint
```

![image](https://user-images.githubusercontent.com/3026413/134245230-0acfe035-292d-4bc3-8910-9751c1005b49.png)
